### PR TITLE
[#157198942] (MR/EL) Pass option to prevent addition of \n newlines when encoding

### DIFF
--- a/android/src/main/java/com/bitgo/randombytes/RandomBytesModule.java
+++ b/android/src/main/java/com/bitgo/randombytes/RandomBytesModule.java
@@ -40,6 +40,6 @@ class RandomBytesModule extends ReactContextBaseJavaModule {
     SecureRandom sr = new SecureRandom();
     byte[] output = new byte[size];
     sr.nextBytes(output);
-    return Base64.encodeToString(output, Base64.DEFAULT);
+    return Base64.encodeToString(output, Base64.NO_WRAP);
   }
 }


### PR DESCRIPTION
When Android encodes strings to base 64, it adds newlines (`\n`) to them by default. This is a royal hassle when we're trying to consume those strings, as it alters the length of the overall string.

There's a handy option to prevent this behavior (`NO_WRAP`), and we've added it in this PR.

Further description available on this SO article: 
https://stackoverflow.com/questions/20040539/new-line-appending-on-my-encrypted-string?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa