### PR TITLE
[#157794957] Unbreak gradle build by merging upstream master

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,5 +13,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.13.+'
+    compile 'com.facebook.react:react-native:+'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-randombytes",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "randomBytes for react-native",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Should fix build breakage issue described in https://github.com/mvayngrib/react-native-randombytes/issues/23